### PR TITLE
 Specifying min node version

### DIFF
--- a/1A - Basic Web/package.json
+++ b/1A - Basic Web/package.json
@@ -13,6 +13,5 @@
   "license": "ISC",
   "dependencies": {
     "express": "^4.13.4",
-    "socket.io": "^1.4.5"
   }
 }

--- a/1A - Basic Web/package.json
+++ b/1A - Basic Web/package.json
@@ -3,12 +3,16 @@
   "version": "1.0.0",
   "description": "a chess game!",
   "main": "app.js",
+  "engines": {
+    "node": ">=6.9.1"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "David",
   "license": "ISC",
   "dependencies": {
-    "express": "^4.13.4"
+    "express": "^4.13.4",
+    "socket.io": "^1.4.5"
   }
 }

--- a/1B - Chess Game/package.json
+++ b/1B - Chess Game/package.json
@@ -13,6 +13,5 @@
   "license": "ISC",
   "dependencies": {
     "express": "^4.13.4",
-    "socket.io": "^1.4.5"
   }
 }

--- a/1B - Chess Game/package.json
+++ b/1B - Chess Game/package.json
@@ -3,12 +3,16 @@
   "version": "1.0.0",
   "description": "a chess game!",
   "main": "app.js",
+  "engines": {
+    "node": ">=6.9.1"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "David",
   "license": "ISC",
   "dependencies": {
-    "express": "^4.13.4"
+    "express": "^4.13.4",
+    "socket.io": "^1.4.5"
   }
 }

--- a/2A - Simple Socket.io/package.json
+++ b/2A - Simple Socket.io/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "description": "a chess game!",
   "main": "app.js",
+  "engines": {
+    "node": ">=6.9.1"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/2B - Connect Game to Socket.io/package.json
+++ b/2B - Connect Game to Socket.io/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "description": "a chess game!",
   "main": "app.js",
+  "engines": {
+    "node": ">=6.9.1"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/2C - Handle moves from Server/package.json
+++ b/2C - Handle moves from Server/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "description": "a chess game!",
   "main": "app.js",
+  "engines": {
+    "node": ">=6.9.1"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/Complete/package.json
+++ b/Complete/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "description": "a chess game!",
   "main": "app.js",
+  "engines": {
+    "node": ">=6.9.1"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
The app was crashing on Azure if the node version was not specified, since Azure is using an older version of node by default which is not compatible with socket.io 2.2.0 const.